### PR TITLE
Fix valid property on OAuthSecurityHandler

### DIFF
--- a/src/arcrest/security/security.py
+++ b/src/arcrest/security/security.py
@@ -861,18 +861,20 @@ class OAuthSecurityHandler(abstract.BaseSecurityHandler):
                               securityHandler=None,
                               proxy_port=self._proxy_port,
                               proxy_url=self._proxy_url)
-
         if 'access_token' in token:
             self._token = token['access_token']
             self._expires_in = token['expires_in']
             self._token_created_on = datetime.datetime.now()
             self._token_expires_on = self._token_created_on + datetime.timedelta(seconds=int(token['expires_in']))
+            self._valid = True
+            self._message = "Token Generated"
         else:
             self._token = None
             self._expires_in = None
             self._token_created_on = None
             self._token_expires_on = None
-            #self._token_expires_on = None
+            self._valid = False
+            self._message = token
 ########################################################################
 class ArcGISTokenSecurityHandler(abstract.BaseSecurityHandler):
     """ handles ArcGIS Maps Token Base Security

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -1,0 +1,26 @@
+# coding: utf-8
+import unittest
+
+from arcrest.security import OAuthSecurityHandler
+
+
+class OAuthSecurityHandlerTests(unittest.TestCase):
+    def test_get_token_with_invalid_client_id_should_not_return_valid_as_true(self):
+        client_id = "invalid_client_id"
+        secret_id = "invalid_secret"
+        org_url = "https://www.arcgis.com"
+
+        oauth_handler = OAuthSecurityHandler(client_id, secret_id, org_url)
+        # Call .token to trigger token generation call
+        self.assertIsNone(oauth_handler.token)
+        self.assertNotEqual(True, oauth_handler.valid)
+
+    def test_get_token_with_invalid_secret_id_should_not_return_valid_as_true(self):
+        client_id = "IXlkCQ0nfEAKbZAP"
+        secret_id = "invalid_secret"
+        org_url = "https://www.arcgis.com"
+
+        oauth_handler = OAuthSecurityHandler(client_id, secret_id, org_url)
+        # Call .token to trigger token generation call
+        self.assertIsNone(oauth_handler.token)
+        self.assertNotEqual(True, oauth_handler.valid)


### PR DESCRIPTION
OAuthSecurityHandler was always returning valid = True even when token generation return "error" 

I've changed it to set valid = False and message = 'token request return value' when 'access_token' is not present in token request return
